### PR TITLE
Use --config-file instead of --repo-config-file when --no-git is set

### DIFF
--- a/task/gitleakstool.ts
+++ b/task/gitleakstool.ts
@@ -23,16 +23,19 @@ export class GitleaksTool {
 		return reportPath;
 	}
 
-	getGitLeaksConfigFileParameter(configType: string, predefinedConfigFile?: string, configFile?: string): string | undefined {
+	getGitLeaksConfigFileParameter(configType: string, nogit: boolean, predefinedConfigFile?: string, configFile?: string): string | undefined {
 		let configFileParameter: string;
 		if (configType.toLowerCase() === 'default') return undefined;
 		else if (configType.toLowerCase() === 'predefined' && predefinedConfigFile !== undefined) {
 			const fullPath = Path.join(__dirname, 'configs', predefinedConfigFile);
 			configFileParameter = `--config-path=${fullPath.replace(/\\/g, '/')}`;
 		}
-		else if (configType.toLowerCase() === 'custom' && configFile !== undefined) {
+		else if (configType.toLowerCase() === 'custom' && configFile !== undefined && !nogit) {
 			configFileParameter = `--repo-config-path=${configFile.replace(/\\/g, '/')}`;
 		}
+        else if (configType.toLowerCase() === 'custom' && configFile !== undefined && nogit) {
+            configFileParameter = `--config-path=${configFile.replace(/\\/g, '/')}`;
+        }
 		else throw new Error(`Incorrect configuration set.`);
 		taskLib.debug(`Config file parameter is set to ${configFileParameter} .`);
 		return configFileParameter;

--- a/task/index.ts
+++ b/task/index.ts
@@ -18,9 +18,10 @@ async function run() {
 
 		const predefinedConfigFile = taskLib.getInput('predefinedconfigfile');
 		const customConfigFile = taskLib.getInput('configfile');
+        const nogit = taskLib.getBoolInput('nogit');
 
 		const gitleaksTool: GitleaksTool = new GitleaksTool('gitleaks', specifiedVersion, operatingSystem, architecture);
-		const configFileParameter = gitleaksTool.getGitLeaksConfigFileParameter(configType, predefinedConfigFile, customConfigFile);
+		const configFileParameter = gitleaksTool.getGitLeaksConfigFileParameter(configType, nogit, predefinedConfigFile, customConfigFile);
 		const reportPath = gitleaksTool.getGitleaksReportPath(agentTempDirectory);
 
 		const cachedTool = await gitleaksTool.getTool();
@@ -34,7 +35,7 @@ async function run() {
 		toolRunner.arg([`--report=${reportPath.replace(/\\/g, '/')}`]);
 		if (configFileParameter) toolRunner.arg([`${configFileParameter}`]);
 
-		if (taskLib.getBoolInput('nogit')) toolRunner.arg([`--no-git`]);
+		if (nogit) toolRunner.arg([`--no-git`]);
 		if (taskLib.getBoolInput('verbose')) toolRunner.arg([`--verbose`]);
 
 		// Set options to run the toolRunner

--- a/task/task.json
+++ b/task/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 11
+        "Patch": 12
     },
     "inputs": [
         {


### PR DESCRIPTION
The task always uses --repo-config-file, making it impossible to use a custom config file in combination with the --no-git switch. When --no-git is set, one must use --config-file.