### PR TITLE
Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ You can display gitleaks report nicely in your Pipeline run summary. To realize 
 ## Changelog
 ### 1.4
 
-- Add option for custom tool location
+- Add option for a custom tool location (so no download)
 - Task input parameters are grouped
-- Updated UDMSecretChecks.toml and GitleaksUdmCombo.toml to latest v7 structure
-- Deprecation warning of 'configtype' value custom. Use customfullpath instead
-- Fixed bug that scanonlychanges and depth cannot work together
+- Updated UDMSecretChecks.toml and GitleaksUdmCombo.toml to latest v7 structure (thanks to Dariusz Porowski)
+- Deprecation warning of 'configtype' value custom. Use customfullpath instead. This is due to upcomming gitleaks 8
+- Fixed bug that scanonlychanges (--commit-file) and depth cannot work together
+- Fixed bug that reportype was a mandatory parameter, will default in code to json
+
 ### 1.3
 
 - Merged Pullrequest from Dariusz Porowski:
@@ -78,6 +80,7 @@ You can display gitleaks report nicely in your Pipeline run summary. To realize 
   - Tests adjusted to report format
   - Added tests for sarif report format upload and end with warring
   - Codebase lint with ts-standard
+  
 ### 1.2
 
 - Added redact option to redact secrets from output

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can display gitleaks report nicely in your Pipeline run summary. To realize 
 - Task input parameters are grouped
 - Updated UDMSecretChecks.toml and GitleaksUdmCombo.toml to latest v7 structure
 - Deprecation warning of 'configtype' value custom. Use customfullpath instead
-
+- Fixed bug that scanonlychanges and depth cannot work together
 ### 1.3
 
 - Merged Pullrequest from Dariusz Porowski:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Thanks to John Lokerse for providing feedback on this extension.
 | Name                 | Description                                                                                                                                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | scanfolder           | The location to be scanned. Defaults to $(Build.SourcesDirectory). This is passed to gitleaks as '--path='                                                                                                                                                                            |
-| configtype           | Can be 'default', 'predefined' or 'custom'. 'default' is using the default gitleaks setup. When set to 'predefined' you can pass the argument 'predefinedconfigfile'. When set to 'custom' you need to pass the argument 'configfile' with the filename of your gitleaks config file. |
+| configtype           | Can be 'default', 'predefined', 'custom' or 'customfullpath'. 'default' is using the default gitleaks setup. When set to 'predefined' you can pass the argument 'predefinedconfigfile'. When set to 'customfullpath' you need to pass the argument 'configfile' with the filename of your gitleaks config file. The value 'custom'  will be deprecated since gitleaks v8 will not support it.|
 | predefinedconfigfile | When set to 'UDMSecretChecks.toml' it uses the Credscan config file provided by Jesse Houwing.                                                                                                                                                                                        |
 | configfile           | Sets the custom configfile in your repo. Use a relative path within the scanfolder. Example: 'config/gitleaks.toml'                                                                                                                                                                   |
 | verbose              | When set to true, gitleaks prints verbose output.                                                                                                                                                                                                                                     |
@@ -42,7 +42,7 @@ Thanks to John Lokerse for providing feedback on this extension.
 | reportformat         | Sets gitleaks report format: JSON, CSV, SARIF (default: json)                                                                                                                                                                                                                         |
 | uploadresults        | When set to true, the results of gitleaks will be uploaded as an artifact to Azure DevOps.                                                                                                                                                                                            |
 | redact               | Redact secrets from log messages and leaks.                                                                                                                                                                                                                                           |
-| taskfail             | Sets the behavior of the task when secrets are detected. When set to `true`, fail the task. When set to `false` and secrets present end with warning.                                                                                                                                 |
+| taskfail             | Sets the behavior of the task when secrets are detected. When set to `true`, fail the task. When set to `false` and secrets present end with warning. Default is true                                                                                                                                 |
 | arguments            | Provide extra arguments to gitleaks. See [GitHub](https://github.com/zricethezav/gitleaks#usage-and-options)                                                                                                                                                                          |
 | version              | Version of Gitleaks to be used. See the gitleaks github page. Set to 'latest' to download the latest version of gitleaks.                                                                                                                                                             |
 
@@ -55,6 +55,12 @@ You can display gitleaks report nicely in your Pipeline run summary. To realize 
 [Github](https://docs.github.com/en/github/authenticating-to-github/removing-sensitive-data-from-a-repository) has a great article on this using the [BFG Repo Cleaner](https://rtyley.github.io/bfg-repo-cleaner/).
 
 ## Changelog
+### 1.4
+
+- Add option for custom tool location
+- Task input parameters are grouped
+- Updated UDMSecretChecks.toml and GitleaksUdmCombo.toml to latest v7 structure
+- Deprecation warning of 'configtype' value custom. Use customfullpath instead
 
 ### 1.3
 
@@ -72,18 +78,15 @@ You can display gitleaks report nicely in your Pipeline run summary. To realize 
   - Tests adjusted to report format
   - Added tests for sarif report format upload and end with warring
   - Codebase lint with ts-standard
-
 ### 1.2
 
 - Added redact option to redact secrets from output
 - Added argument field to pass more options to gitleaks
 - Added option to scan only for changes between this build and the previous build
 - Bumped node packages to the latest
-
 ### 1.1
 
 - First public release
-
 ### 1.0
 
 - Initial version, not public

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: '1.3$(rev:.r)'
+name: '1.4$(rev:.r)'
 
 trigger:
 - main

--- a/task/configs/GitleaksUdmCombo.toml
+++ b/task/configs/GitleaksUdmCombo.toml
@@ -168,7 +168,6 @@ title = "gitleaks config"
     regex = '''pypi-AgEIcHlwaS5vcmc[A-Za-z0-9-_]{50,1000}'''
     tags = ["key", "pypi"]
 
-
 [[rules]]
 	description = "CSCAN0210: GitCredential" 
 	regex = '''https?://.+:.+@.*'''
@@ -193,10 +192,9 @@ title = "gitleaks config"
 	description = "CSCAN0030: PublishSettings"
 	regex = '''userPWD="[a-zA-Z0-9\+\/]{60}"'''
 	file = '''(?i)(publishsettings|\.pubxml$)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0060: PemFile 1" 
@@ -207,35 +205,32 @@ title = "gitleaks config"
 	description = "CSCAN0091: AspNetMachineKeyInConfig 1" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<machineKey[^>]+(?:decryptionKey\s*\=\s*"[a-fA-F0-9]{48,}|validationKey\s*\=\s*"[a-fA-F0-9]{48,})[^>]+>'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0091: AspNetMachineKeyInConfig 2" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''(?:decryptionKey|validationKey)="[a-zA-Z0-9]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0092: SqlConnectionStringInConfig 1" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''(?i)(?:connection[sS]tring|connString)[^=]*=["'][^"']*[pP]assword\s*=\s*[^\s;][^"']*(?:'|")'''
-	[[rules.whitelist]]
+	[rules.allowlist]
 		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
 
 [[rules]]
 	description = "CSCAN0092: SqlConnectionStringInConfig 2 / CSCAN0043 SqlConnectionStringInCode" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties|policy_and_key\.hpp|AccountConfig\.h)$|hubot'''
 	regex = '''(?i)(?:User ID|uid|UserId).*(?:Password|[^a-z]pwd)=[^'\$%<@'";\[\{][^;/"]{4,128}(?:;|")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:prefix <<|guestaccesstoken|skiptoken|cookie|tsm|fake|example|badlyFormatted|Invalid|sha512|sha256|"input"|ENCRYPTED|"EncodedRequestUri"|looks like|myStorageAccountName|(?:0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:prefix <<|guestaccesstoken|skiptoken|cookie|tsm|fake|example|badlyFormatted|Invalid|sha512|sha256|"input"|ENCRYPTED|"EncodedRequestUri"|looks like|myStorageAccountName|(?:0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0093: StorageAccountKeyInConfig 1" 
@@ -271,69 +266,49 @@ title = "gitleaks config"
 	description = "CSCAN0095: GeneralSecretInConfig 1" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<add\skey="[^"]+(?:key(?:s|[0-9])?|credentials?|secret(?:s|[0-9])?|password|token|KeyPrimary|KeySecondary|KeyOrSas|KeyEncrypted)"\s*value\s*="[^"]+"[^>]*/>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 2" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<add\skey="[^"]+"\s*value="[^"]*EncryptedSecret:[^"]+"\s*/>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 3" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<Credential\sname="[^"]*(?:key(?:s|[0-9])?|credentials?|secret(?:s|[0-9])?|password|token|KeyPrimary|KeySecondary|KeyOrSas|KeyEncrypted)"(\s*value\s*="[^"]+".*?/>|[^>]*>.*?</Credential>)'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 4" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<setting\sname="[^"]*Password".*[\r?\n]*\s*<value>.+</value>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0110: ScriptPassword 1" 
@@ -354,70 +329,63 @@ title = "gitleaks config"
 	description = "CSCAN0220: DefaultPasswordContexts 1" 
 	file = '''\.(?:ps1|psm1|)$'''
 	regex = '''ConvertTo-SecureString(?:\s*-String)?\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 2" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''new\sX509Certificate2\([^()]*,\s*"[^"\r?\n]+"[^)]*\)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 3" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''AdminPassword\s*=\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 4" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''(?i)<password>.+</password>'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 5" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''ClearTextPassword"?\s*[:=]\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 6" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''certutil.*?\-p\s+("[^"%]+"|'[^'%]+'|[^"']\S*\s)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 7" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''password\s*=\s*N?(["][^"\r?\n]{4,}["]|['][^'\r?\n]{4,}['])'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0160: DomainPassword"
 	regex = '''new(?:-object)?\s+System.Net.NetworkCredential\(?:.*?,\s*"[^"]+"'''
 	file = '''\.cs$|\.c$|\.cpp$|\.ps1$|\.ps$|\.cmd$|\.bat$|\.log$|\.psd$|\.psm1$'''
-	[[rules.whitelist]]
+	[rules.allowlist]
 		regex = '''(%1%|\$MIGUSER_PASSWORD|%miguser_pwd%)'''
 		description = "ignore placeholders"
 
@@ -448,7 +416,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "CSCAN0230: SlackToken 1" 
-    regex = '''xoxp-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+'''
+	regex = '''xoxp-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+'''
 	file = '''\.(?:ps1|psm1|js|json|coffee|xml|js|md|html|py|php|java|ipynb|rb)$|hubot'''
 
 [[rules]]

--- a/task/configs/UDMSecretChecks.toml
+++ b/task/configs/UDMSecretChecks.toml
@@ -24,10 +24,9 @@ title = "gitleaks config"
 	description = "CSCAN0030: PublishSettings"
 	regex = '''userPWD="[a-zA-Z0-9\+\/]{60}"'''
 	file = '''(?i)(publishsettings|\.pubxml$)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0060: PemFile 1" 
@@ -38,35 +37,32 @@ title = "gitleaks config"
 	description = "CSCAN0091: AspNetMachineKeyInConfig 1" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<machineKey[^>]+(?:decryptionKey\s*\=\s*"[a-fA-F0-9]{48,}|validationKey\s*\=\s*"[a-fA-F0-9]{48,})[^>]+>'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0091: AspNetMachineKeyInConfig 2" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''(?:decryptionKey|validationKey)="[a-zA-Z0-9]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0092: SqlConnectionStringInConfig 1" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''(?i)(?:connection[sS]tring|connString)[^=]*=["'][^"']*[pP]assword\s*=\s*[^\s;][^"']*(?:'|")'''
-	[[rules.whitelist]]
+	[rules.allowlist]
 		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
 
 [[rules]]
 	description = "CSCAN0092: SqlConnectionStringInConfig 2 / CSCAN0043 SqlConnectionStringInCode" 
 	file = '''\.(?:xml|pubxml|definitions|ps1|wadcfgx|ccf|config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties|policy_and_key\.hpp|AccountConfig\.h)$|hubot'''
 	regex = '''(?i)(?:User ID|uid|UserId).*(?:Password|[^a-z]pwd)=[^'\$%<@'";\[\{][^;/"]{4,128}(?:;|")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:prefix <<|guestaccesstoken|skiptoken|cookie|tsm|fake|example|badlyFormatted|Invalid|sha512|sha256|"input"|ENCRYPTED|"EncodedRequestUri"|looks like|myStorageAccountName|(?:0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:prefix <<|guestaccesstoken|skiptoken|cookie|tsm|fake|example|badlyFormatted|Invalid|sha512|sha256|"input"|ENCRYPTED|"EncodedRequestUri"|looks like|myStorageAccountName|(?:0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0093: StorageAccountKeyInConfig 1" 
@@ -102,69 +98,49 @@ title = "gitleaks config"
 	description = "CSCAN0095: GeneralSecretInConfig 1" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<add\skey="[^"]+(?:key(?:s|[0-9])?|credentials?|secret(?:s|[0-9])?|password|token|KeyPrimary|KeySecondary|KeyOrSas|KeyEncrypted)"\s*value\s*="[^"]+"[^>]*/>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 2" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<add\skey="[^"]+"\s*value="[^"]*EncryptedSecret:[^"]+"\s*/>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 3" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<Credential\sname="[^"]*(?:key(?:s|[0-9])?|credentials?|secret(?:s|[0-9])?|password|token|KeyPrimary|KeySecondary|KeyOrSas|KeyEncrypted)"(\s*value\s*="[^"]+".*?/>|[^>]*>.*?</Credential>)'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0095: GeneralSecretInConfig 4" 
 	file = '''\.(?:config|cscfg|json|js|txt|cpp|sql|dtsx|md|java|FF|template|settings|ini|BF|ste|isml|test|ts|resx|Azure|sample|backup|rd|hpp|psm1|cshtml|htm|bat|waz|yml|Beta|py|sh|m|php|xaml|keys|cmd|rds|loadtest|properties)$|hubot'''
 	regex = '''<setting\sname="[^"]*Password".*[\r?\n]*\s*<value>.+</value>'''
-	[[rules.whitelist]]
-		regex = '''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"'''
-	[[rules.whitelist]]
-		regex = '''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
-	[[rules.whitelist]]
-		regex = '''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)'''
-	[[rules.whitelist]]
-		regex = '''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}'''
+	[rules.allowlist]
+		regex = ['''key\s*=\s*"[^"]*AppKey[^"]*"\s+value\s*=\s*"[a-z]+"''',
+		'''value\s*=\s*"(?:[a-z]+(?: [a-z]+)+"|_+[a-z]+_+"|[a-z]+-[a-z]+-[a-z]+["-]|[a-z]+-[a-z]+"|[a-z]+\\[a-z]+"|\d+"|[^"]*ConnectionString")''',
+		'''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''',
+		'''value="(?:true|false|@\(api|ssh\-rsa 2048|invalid|to be|a shared secret|secreturi|clientsecret|Overr?idden by|someValue|SOME\-SIGNING\-KEY|TokenBroker|UNKNOWN|Client Secret of|Junk Credentials|Default\-|__BOOTSTRAPKEY_|CacheSecret|CatalogCert|CosmosCredentials|DeleteServiceCert|EmailCredentials|MetricsConnection|SangamCredentials|SubscriptionConnection|Enter_your_|My_Issuer|ScaleUnitXstoreSharedKey|private_powerapps|TestSecret|foo_|bar_|temp_|__WinfabricTestInfra|configured|SecretFor|Test|XSTORE_KEY|ServiceBusDiagnosticXstoreSharedKey|BoxApplicationKey|googleapps)''',
+		'''AccountKey\s*=\s*MII[a-z0-9/+]{43,}={0,2}''']
 
 [[rules]]
 	description = "CSCAN0110: ScriptPassword 1" 
@@ -185,70 +161,63 @@ title = "gitleaks config"
 	description = "CSCAN0220: DefaultPasswordContexts 1" 
 	file = '''\.(?:ps1|psm1|)$'''
 	regex = '''ConvertTo-SecureString(?:\s*-String)?\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 2" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''new\sX509Certificate2\([^()]*,\s*"[^"\r?\n]+"[^)]*\)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 3" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''AdminPassword\s*=\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 4" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''(?i)<password>.+</password>'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 5" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''ClearTextPassword"?\s*[:=]\s*"[^"\r?\n]+"'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 6" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''certutil.*?\-p\s+("[^"%]+"|'[^'%]+'|[^"']\S*\s)'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 	
 [[rules]]
 	description = "CSCAN0220: DefaultPasswordContexts 7" 
 	file = '''\.(?:cs|xml|config|json|ts|cfg|txt|ps1|bat|cscfg|publishsettings|cmd|psm1|aspx|asmx|vbs|added_cluster|clean|pubxml|ccf|ini|svd|sql|c|xslt|csv|FF|ExtendedTests|settings|cshtml|template|trd|argfile)$|(config|certificate|publish|UT)\.js$|(commands|user|tests)\.cpp$'''
 	regex = '''password\s*=\s*N?(["][^"\r?\n]{4,}["]|['][^'\r?\n]{4,}['])'''
-	[[rules.whitelist]]
-		regex = '''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager'''
-	[[rules.whitelist]]
-		regex = '''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})'''
+	[rules.allowlist]
+		regex = ['''Credentials?Type|ConnectionStringKey|notasecret|PartitionKey|notreal|insertkey|LookupKey|IgnoreKeys|SecretsService|SecretsTenantId|(?:Password|pwd|secret|credentials?)(?:Key|Location)|KeyManager''',
+		'''(?:_AppKey"|(?:(?:credential|password|token)s?|(?:Account|access)Key=)"[\s\r?\n]*/|Username"|\.dll|(?:Secret|Token|Key|Credential)s?(?:Encryption|From|(?:Signing)?Certificate|Options|Thumbprint|Contacts|String|UserId)|Key(1;value1|word|s?Path|Index|Id|Store|WillDoWithoutValidation|:NamePattern|Name"|Ref")|(Secret|Credential)s?(Name|Path)"|(StrongName|Chaos\s?Mon|Redis|Registry|Registery|User|Insights?|Instrumentation|Match\()Key|(Certificate|cert)(Issuer|Subject)|rollingdate|skuId|HKEY_|AddServicePrincipalCredentials|Password Resets|SecretStore|(0|x|\*){8,})''']
 
 [[rules]]
 	description = "CSCAN0160: DomainPassword"
 	regex = '''new(?:-object)?\s+System.Net.NetworkCredential\(?:.*?,\s*"[^"]+"'''
 	file = '''\.cs$|\.c$|\.cpp$|\.ps1$|\.ps$|\.cmd$|\.bat$|\.log$|\.psd$|\.psm1$'''
-	[[rules.whitelist]]
+	[rules.allowlist]
 		regex = '''(%1%|\$MIGUSER_PASSWORD|%miguser_pwd%)'''
 		description = "ignore placeholders"
 
@@ -279,7 +248,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "CSCAN0230: SlackToken 1" 
-    regex = '''xoxp-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+'''
+	regex = '''xoxp-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+-[a-z0-9]+'''
 	file = '''\.(?:ps1|psm1|js|json|coffee|xml|js|md|html|py|php|java|ipynb|rb)$|hubot'''
 
 [[rules]]
@@ -287,9 +256,12 @@ title = "gitleaks config"
 	regex = '''xoxb-[a-z0-9]+-[a-z0-9]+'''
 	file = '''\.(?:ps1|psm1|js|json|coffee|xml|js|md|html|py|php|java|ipynb|rb)$|hubot'''
 
-[whitelist]
-	description = "image whitelists"
-	files = ['''(.*?)(jpg|gif|doc|pdf|bin)$''','''buildsearchers.xml''']
+[allowlist]
+	description = "Allowlisted files"
+	files = ['''(.*?)(png|jpg|gif|tif|tiff|doc|docx|pdf|bin|xls|pyc|zip)$''',
+	'''buildsearchers.xml''',
+	'''^\.?gitleaks.toml$''',
+	'''^\.?UDMSecretChecks.toml$''']
 	commits = []
   	paths = []
 	repos = []

--- a/task/index.ts
+++ b/task/index.ts
@@ -28,10 +28,7 @@ async function run () {
     const nogit = taskLib.getBoolInput('nogit')
     const scanonlychanges = taskLib.getBoolInput('scanonlychanges')
     const reportformat = taskLib.getInput('reportformat') || 'json'
-
-    let taskfail = true
-    try { taskfail = taskLib.getBoolInput('taskfail', true) }
-    catch { taskfail = true }
+    const taskfail = taskLib.getBoolInput('taskfail')
     
     const gitleaksTool: GitleaksTool = new GitleaksTool(specifiedVersion, operatingSystem, architecture)
     const configFileParameter = gitleaksTool.getGitLeaksConfigFileParameter(configType, nogit, predefinedConfigFile, customConfigFile)

--- a/task/index.ts
+++ b/task/index.ts
@@ -53,9 +53,10 @@ async function run () {
       const azureDevOpsAPI: AzureDevOpsAPI = new AzureDevOpsAPI()
       const commitsFile = await azureDevOpsAPI.getBuildChangesInFile(agentTempDirectory)
       toolRunner.arg([`--commits-file=${commitsFile}`])
-      const depth = taskLib.getInput('depth')
-      toolRunner.argIf(depth, [`--depth=${depth}`])
     }
+
+    const depth = taskLib.getInput('depth')
+    if (depth) toolRunner.argIf(depth, [`--depth=${depth}`])
 
     // Process extra arguments
     if (gitleaksArguments) {

--- a/task/task.json
+++ b/task/task.json
@@ -193,7 +193,7 @@
             "type": "string",
             "label": "Gitleaks custom tool location",
             "required": false,
-            "helpMarkDown": "Specify the custom location of Gitleaks, when provided, Gitleaks will not be downloaded.",
+            "helpMarkDown": "Specify the custom directory of Gitleaks, when provided, Gitleaks will not be downloaded.",
             "groupName": "gitleakstool"
         }
     ],

--- a/task/task.json
+++ b/task/task.json
@@ -70,10 +70,10 @@
             "defaultValue": "default",
             "required": false,
             "options": {
-                "default": "default",
-                "predefined": "predefined",
+                "default": "Default",
+                "predefined": "Predefined",
                 "custom": "Custom configuration (will be deprecated)",
-                "customfullpath": "Full path to custom configuration"
+                "customfullpath": "Custom configuration (full path)"
             },
             "helpMarkDown": "Specify if you want to use the default, predefined config or a custom config.",
             "groupName": "scanconfiguration"
@@ -118,7 +118,7 @@
             "label": "Number of commits to scan",
             "helpMarkDown": "Limit the number of commits to scan.",
             "required": false,
-            "visibleRule": "scanonlychanges=true",
+            "visibleRule": "nogit=false && scanonlychanges=false",
             "groupName": "scanoptions"
         },
         {

--- a/task/task.json
+++ b/task/task.json
@@ -31,7 +31,7 @@
         {
             "name": "scanoptions",
             "displayName": "Scan options",
-            "isExpanded": true
+            "isExpanded": false
         },
         {
             "name": "behaviour",

--- a/task/task.json
+++ b/task/task.json
@@ -142,7 +142,7 @@
         {
             "name": "taskfail",
             "type": "boolean",
-            "label": "Fail the task if secrets founded",
+            "label": "Fail the task if secrets are found.",
             "defaultValue": "true",
             "required": false,
             "groupName": "behaviour"

--- a/task/task.json
+++ b/task/task.json
@@ -161,7 +161,7 @@
             "type": "pickList",
             "label": "Report format",
             "defaultValue": "json",
-            "required": true,
+            "required": false,
             "options": {
                 "json": "json",
                 "sarif": "sarif",

--- a/task/task.json
+++ b/task/task.json
@@ -35,7 +35,7 @@
         },
         {
             "name": "behaviour",
-            "displayName": "Behaviour",
+            "displayName": "Task Behaviour",
             "isExpanded": false
         },
         {
@@ -60,7 +60,7 @@
             "label": "No Git",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Treat git repos as plain directories and scan those files.",
+            "helpMarkDown": "Treat git repos as plain directories.",
             "groupName": "scanlocation"
         },
         {
@@ -106,6 +106,7 @@
             "name": "scanonlychanges",
             "type": "boolean",
             "label": "Scan only changes since last build",
+            "helpMarkDown": "Will fetch the commits since last succesful build from the Azure DevOps Api.",
             "defaultValue": "false",
             "required": false,
             "visibleRule": "nogit=false",
@@ -115,8 +116,9 @@
             "name": "depth",
             "type": "int",
             "label": "Number of commits to scan",
+            "helpMarkDown": "Limit the number of commits to scan.",
             "required": false,
-            "visibleRule": "nogit=false",
+            "visibleRule": "scanonlychanges=true",
             "groupName": "scanoptions"
         },
         {
@@ -189,7 +191,7 @@
         {
             "name": "customtoollocation",
             "type": "string",
-            "label": "Gitleaks custom tool locatiomn",
+            "label": "Gitleaks custom tool location",
             "required": false,
             "helpMarkDown": "Specify the custom location of Gitleaks, when provided, Gitleaks will not be downloaded.",
             "groupName": "gitleakstool"

--- a/task/task.json
+++ b/task/task.json
@@ -14,9 +14,36 @@
     "author": "Joost Voskuil (joost@foxhole.nl)",
     "version": {
         "Major": 1,
-        "Minor": 3,
+        "Minor": 4,
         "Patch": 0
     },
+    "groups": [
+        {
+            "name": "scanlocation",
+            "displayName": "Scan Location",
+            "isExpanded": true
+        },
+        {
+            "name": "scanconfiguration",
+            "displayName": "Scan configuration",
+            "isExpanded": true
+        },
+        {
+            "name": "scanoptions",
+            "displayName": "Scan options",
+            "isExpanded": true
+        },
+        {
+            "name": "behaviour",
+            "displayName": "Behaviour",
+            "isExpanded": false
+        },
+        {
+            "name": "gitleakstool",
+            "displayName": "Gitleaks Tool location and version",
+            "isExpanded": false
+        }
+    ],
     "inputs": [
         {
             "name": "scanfolder",
@@ -24,7 +51,17 @@
             "label": "Scan Folder",
             "defaultValue": "$(Build.SourcesDirectory)",
             "required": true,
-            "helpMarkDown": "Specify the location to scan. Defaults to your sources directory."
+            "helpMarkDown": "Specify the location to scan. Defaults to your sources directory.",
+            "groupName": "scanlocation"
+        },
+        {
+            "name": "nogit",
+            "type": "boolean",
+            "label": "No Git",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Treat git repos as plain directories and scan those files.",
+            "groupName": "scanlocation"
         },
         {
             "name": "configtype",
@@ -35,9 +72,11 @@
             "options": {
                 "default": "default",
                 "predefined": "predefined",
-                "custom": "custom"
+                "custom": "Custom configuration (will be deprecated)",
+                "customfullpath": "Full path to custom configuration"
             },
-            "helpMarkDown": "Specify if you want to use the default, predefined config or a custom config."
+            "helpMarkDown": "Specify if you want to use the default, predefined config or a custom config.",
+            "groupName": "scanconfiguration"
         },
         {
             "name": "predefinedconfigfile",
@@ -50,24 +89,18 @@
                 "GitleaksUdmCombo.toml": "GitleaksUdmCombo.toml"
             },
             "helpMarkDown": "Select a predefined config file.",
-            "visibleRule": "configtype=predefined"
+            "visibleRule": "configtype=predefined",
+            "groupName": "scanconfiguration"
         },
         {
             "name": "configfile",
             "type": "string",
             "label": "Config file",
-            "defaultValue": "config/gitleaks.toml",
+            "defaultValue": "$(Build.SourcesDirectory)/config/gitleaks.toml",
             "required": true,
-            "helpMarkDown": "Specify a custom config file inside your repo.",
-            "visibleRule": "configtype=custom"
-        },
-        {
-            "name": "nogit",
-            "type": "boolean",
-            "label": "No Git",
-            "defaultValue": "false",
-            "required": false,
-            "helpMarkDown": "Treat git repos as plain directories and scan those files."
+            "helpMarkDown": "Specify a custom config file.",
+            "visibleRule": "configtype=custom || configtype=customfullpath",
+            "groupName": "scanconfiguration"
         },
         {
             "name": "scanonlychanges",
@@ -75,22 +108,51 @@
             "label": "Scan only changes since last build",
             "defaultValue": "false",
             "required": false,
-            "visibleRule": "nogit=false"
+            "visibleRule": "nogit=false",
+            "groupName": "scanoptions"
         },
         {
             "name": "depth",
             "type": "int",
             "label": "Number of commits to scan",
             "required": false,
-            "visibleRule": "nogit=false"
+            "visibleRule": "nogit=false",
+            "groupName": "scanoptions"
         },
         {
-            "name": "verbose",
+            "name": "redact",
             "type": "boolean",
-            "label": "Verbose output",
+            "label": "Redact",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Check this option if you want gitleaks to print verbose output."
+            "helpMarkDown": "Check this option if you want to redact secrets from log messages and leaks.",
+            "groupName": "scanoptions"
+        },
+        {
+            "name": "arguments",
+            "type": "string",
+            "label": "Extra gitleaks arguments",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Specify extra Gitleaks arguments.",
+            "groupName": "scanoptions"
+        },
+        {
+            "name": "taskfail",
+            "type": "boolean",
+            "label": "Fail the task if secrets founded",
+            "defaultValue": "true",
+            "required": false,
+            "groupName": "behaviour"
+        },
+        {
+            "name": "uploadresults",
+            "type": "boolean",
+            "label": "Upload results",
+            "defaultValue": "true",
+            "required": false,
+            "helpMarkDown": "Check this option if you want to upload the results as an artifact.",
+            "groupName": "behaviour"
         },
         {
             "name": "reportformat",
@@ -103,38 +165,17 @@
                 "sarif": "sarif",
                 "csv": "csv"
             },
-            "helpMarkDown": "Select a report format: json, sarif, csv (default: json)"
+            "helpMarkDown": "Select a report format: json, sarif, csv (default: json)",
+            "groupName": "behaviour"
         },
         {
-            "name": "uploadresults",
+            "name": "verbose",
             "type": "boolean",
-            "label": "Upload results",
-            "defaultValue": "true",
-            "required": false,
-            "helpMarkDown": "Check this option if you want to upload the results as an artifact."
-        },
-        {
-            "name": "redact",
-            "type": "boolean",
-            "label": "Redact",
+            "label": "Verbose output",
             "defaultValue": "false",
             "required": false,
-            "helpMarkDown": "Check this option if you want to redact secrets from log messages and leaks."
-        },
-        {
-            "name": "taskfail",
-            "type": "boolean",
-            "label": "Fail the task if secrets founded",
-            "defaultValue": "true",
-            "required": false
-        },
-        {
-            "name": "arguments",
-            "type": "string",
-            "label": "Extra gitleaks arguments",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "Specify extra Gitleaks arguments."
+            "helpMarkDown": "Check this option if you want gitleaks to print verbose output.",
+            "groupName": "behaviour"
         },
         {
             "name": "version",
@@ -142,7 +183,16 @@
             "label": "Gitleaks version",
             "defaultValue": "latest",
             "required": false,
-            "helpMarkDown": "Specify the version of Gitleaks to use."
+            "helpMarkDown": "Specify the version of Gitleaks to use.",
+            "groupName": "gitleakstool"
+        },
+        {
+            "name": "customtoollocation",
+            "type": "string",
+            "label": "Gitleaks custom tool locatiomn",
+            "required": false,
+            "helpMarkDown": "Specify the custom location of Gitleaks, when provided, Gitleaks will not be downloaded.",
+            "groupName": "gitleakstool"
         }
     ],
     "execution": {
@@ -175,6 +225,8 @@
         "GetEndpointAuthorizationParameterEmpty": "GetEndpointAuthorizationParameter %s is empty",
         "VariableEmpty": "Variable %s is empty",
         "InputEmpty": "Input %s is empty",
-        "AdoConnectionError": "Connection cannot be made to Azure DevOps."
+        "AdoConnectionError": "Connection cannot be made to Azure DevOps.",
+        "GitLeaksNotFound": "Gitleaks cannot be found at %s",
+        "WarningBehaviourChangeGitleak8": "The behaviour will change in future releases of this task. Please set 'configtype' to 'customfullpath' and specify the full path to the Gitleask config file."
     }
 }

--- a/task/tests/ConfigFiles_ShouldAcceptCustomConfigFile.ts
+++ b/task/tests/ConfigFiles_ShouldAcceptCustomConfigFile.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -21,6 +19,8 @@ tmr.setInput('configfile', configFile);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 helpers.BuildWithDefaultValues();
 tmr = helpers.BuildWithEmptyToolCache(tmr);

--- a/task/tests/ConfigFiles_ShouldAcceptNoConfig.ts
+++ b/task/tests/ConfigFiles_ShouldAcceptNoConfig.ts
@@ -16,8 +16,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
-
-
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 helpers.BuildWithDefaultValues();
 

--- a/task/tests/ConfigFiles_ShouldAcceptPredefinedConfig.ts
+++ b/task/tests/ConfigFiles_ShouldAcceptPredefinedConfig.ts
@@ -1,11 +1,7 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
-import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
-
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
-import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
 let tmr: mr.TaskMockRunner = new mr.TaskMockRunner(taskPath);
@@ -19,6 +15,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const configFile = `${path.join(__dirname, '../')}configs/UDMSecretChecks.toml`

--- a/task/tests/ConfigFiles_ShouldFailWhenCustomConfigFileIsNotProvided.ts
+++ b/task/tests/ConfigFiles_ShouldFailWhenCustomConfigFileIsNotProvided.ts
@@ -1,11 +1,7 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
-import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
-
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
-import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
 let tmr: mr.TaskMockRunner = new mr.TaskMockRunner(taskPath);
@@ -19,6 +15,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const configFile = `${path.join(__dirname, '../')}configs/UDMSecretChecks.toml`

--- a/task/tests/Execution_ShouldFailWhenGitLeaksReturnsExitCodeOne.ts
+++ b/task/tests/Execution_ShouldFailWhenGitLeaksReturnsExitCodeOne.ts
@@ -1,9 +1,7 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -19,6 +17,7 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/Execution_ShouldSucceedWhenGitLeaksReturnsExitCodeZero.ts
+++ b/task/tests/Execution_ShouldSucceedWhenGitLeaksReturnsExitCodeZero.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -17,6 +15,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/GitleaksCall_ShouldWorkWithDefaultParameters.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithDefaultParameters.ts
@@ -1,6 +1,5 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -14,6 +13,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/GitleaksCall_ShouldWorkWithNoGitParameter.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithNoGitParameter.ts
@@ -1,7 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -17,6 +16,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const reportformat = 'json';

--- a/task/tests/GitleaksCall_ShouldWorkWithOneArgument.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithOneArgument.ts
@@ -1,7 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -18,6 +17,8 @@ tmr.setInput('arguments', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
 tmr.setInput('arguments', '--arg1=value');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const reportformat = 'json';

--- a/task/tests/GitleaksCall_ShouldWorkWithRedactParameter.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithRedactParameter.ts
@@ -1,7 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -17,6 +16,7 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('redact', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const reportformat = 'json';

--- a/task/tests/GitleaksCall_ShouldWorkWithTwoArguments.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithTwoArguments.ts
@@ -1,7 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -18,6 +17,8 @@ tmr.setInput('arguments', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
 tmr.setInput('arguments', '--arg1=value --arg2');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const reportformat = 'json';

--- a/task/tests/GitleaksCall_ShouldWorkWithVerboseParameter.ts
+++ b/task/tests/GitleaksCall_ShouldWorkWithVerboseParameter.ts
@@ -1,7 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -17,6 +16,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'true');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 const reportformat = 'json';

--- a/task/tests/GitleaksRelease_ShouldDownloadWhenNotInToolCache.ts
+++ b/task/tests/GitleaksRelease_ShouldDownloadWhenNotInToolCache.ts
@@ -1,8 +1,5 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
-
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -16,6 +13,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/GitleaksRelease_ShouldNotDownloadWhenInToolCache.ts
+++ b/task/tests/GitleaksRelease_ShouldNotDownloadWhenInToolCache.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -16,6 +14,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/GitleaksRelease_ShouldWorkOnDarwinX64.ts
+++ b/task/tests/GitleaksRelease_ShouldWorkOnDarwinX64.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');
@@ -16,6 +14,7 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('taskfail', 'true');
 
 // Agent settings
 process.env['AGENT_OS'] = 'Darwin';

--- a/task/tests/GitleaksRelease_ShouldWorkOnLinuxArm.ts
+++ b/task/tests/GitleaksRelease_ShouldWorkOnLinuxArm.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksRelease_ShouldWorkOnLinuxx64.ts
+++ b/task/tests/GitleaksRelease_ShouldWorkOnLinuxx64.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksRelease_ShouldWorkOnWindowsNTx64.ts
+++ b/task/tests/GitleaksRelease_ShouldWorkOnWindowsNTx64.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksRelease_ShouldWorkOnWindowsNTx86.ts
+++ b/task/tests/GitleaksRelease_ShouldWorkOnWindowsNTx86.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksVersion_ShouldDownloadedWhenLatest.ts
+++ b/task/tests/GitleaksVersion_ShouldDownloadedWhenLatest.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksVersion_ShouldDownloadedWhenSpecified.ts
+++ b/task/tests/GitleaksVersion_ShouldDownloadedWhenSpecified.ts
@@ -1,8 +1,6 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 
-
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 
 const taskPath = path.join(__dirname, '..', 'index.js');

--- a/task/tests/GitleaksVersion_ShouldFailWhenCustomToolLocationCanNotBeFound.ts
+++ b/task/tests/GitleaksVersion_ShouldFailWhenCustomToolLocationCanNotBeFound.ts
@@ -2,6 +2,7 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
+
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -9,18 +10,18 @@ const taskPath = path.join(__dirname, '..', 'index.js');
 let tmr: mr.TaskMockRunner = new mr.TaskMockRunner(taskPath);
 
 // Inputs
-tmr.setInput('version', 'latest');
+tmr.setInput('customtoollocation', 'customtoollocation');
 tmr.setInput('configType', 'default');
 
 tmr.setInput('scanfolder', __dirname);
 
-tmr.setInput('nogit', 'false');
+tmr.setInput('redact', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
-tmr.setInput('taskfail', 'false');
-tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
+const reportformat = 'json';
 
 helpers.BuildWithDefaultValues();
 tmr = helpers.BuildWithEmptyToolCache(tmr);
@@ -29,11 +30,16 @@ tmr.registerMock('azure-pipelines-task-lib/toolrunner', mtr);
 
 tmr.setAnswers(<TaskLibAnswers>{
         exec: {
-                [helpers.createToolCall(executable)]: {
-                        'code': 1,
+                [createToolCall(reportformat)]: {
+                        'code': 0,
                         'stdout': 'Gitleaks tool console output',
                 },
-        },
+        }
 });
 
 tmr.run();
+
+function createToolCall(reportformat: string): string {
+	const toolCall = `/customtoollocation/${executable} --path=${__dirname} --report=${helpers.reportFile(reportformat)} --format=${reportformat} --redact`;
+	return toolCall;
+}

--- a/task/tests/GitleaksVersion_ShouldSucceedWithCustomLocation.ts
+++ b/task/tests/GitleaksVersion_ShouldSucceedWithCustomLocation.ts
@@ -2,6 +2,7 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
+
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -9,18 +10,18 @@ const taskPath = path.join(__dirname, '..', 'index.js');
 let tmr: mr.TaskMockRunner = new mr.TaskMockRunner(taskPath);
 
 // Inputs
-tmr.setInput('version', 'latest');
+tmr.setInput('customtoollocation', '/customtoollocation');
 tmr.setInput('configType', 'default');
 
 tmr.setInput('scanfolder', __dirname);
 
-tmr.setInput('nogit', 'false');
+tmr.setInput('redact', 'true');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
-tmr.setInput('taskfail', 'false');
-tmr.setInput('redact', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
+const reportformat = 'json';
 
 helpers.BuildWithDefaultValues();
 tmr = helpers.BuildWithEmptyToolCache(tmr);
@@ -29,11 +30,23 @@ tmr.registerMock('azure-pipelines-task-lib/toolrunner', mtr);
 
 tmr.setAnswers(<TaskLibAnswers>{
         exec: {
-                [helpers.createToolCall(executable)]: {
-                        'code': 1,
+                [createToolCall(reportformat)]: {
+                        'code': 0,
                         'stdout': 'Gitleaks tool console output',
                 },
+        },
+        exist: {
+                [mockTool()]: true,
         },
 });
 
 tmr.run();
+
+function mockTool(): string {
+        return `/customtoollocation/${executable}`;
+}
+
+function createToolCall(reportformat: string): string {
+        const toolCall = `/customtoollocation/${executable} --path=${__dirname} --report=${helpers.reportFile(reportformat)} --format=${reportformat} --redact`;
+        return toolCall;
+}

--- a/task/tests/MockHelper.ts
+++ b/task/tests/MockHelper.ts
@@ -1,6 +1,5 @@
 import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
-import path = require('path');
 
 export function BuildWithDefaultValues(): void {
 	process.env['AGENT_TOOLSDIRECTORY'] = __dirname;

--- a/task/tests/UploadResults_ShouldNotUploadFileResultsWhenReportFileDoesNotExist.ts
+++ b/task/tests/UploadResults_ShouldNotUploadFileResultsWhenReportFileDoesNotExist.ts
@@ -2,7 +2,6 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 

--- a/task/tests/UploadResults_ShouldNotUploadFileResultsWhenReportFileDoesNotExist.ts
+++ b/task/tests/UploadResults_ShouldNotUploadFileResultsWhenReportFileDoesNotExist.ts
@@ -16,6 +16,7 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/UploadResults_ShouldNotUploadFileResultsWhenUploadIsOff.ts
+++ b/task/tests/UploadResults_ShouldNotUploadFileResultsWhenUploadIsOff.ts
@@ -16,6 +16,7 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'false');
+tmr.setInput('taskfail', 'true');
 
 const executable = 'gitleaks-darwin-amd64';
 

--- a/task/tests/UploadResults_ShouldNotUploadFileResultsWhenUploadIsOff.ts
+++ b/task/tests/UploadResults_ShouldNotUploadFileResultsWhenUploadIsOff.ts
@@ -2,7 +2,6 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 

--- a/task/tests/UploadResults_ShouldUploadFileResults.ts
+++ b/task/tests/UploadResults_ShouldUploadFileResults.ts
@@ -16,6 +16,8 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
+tmr.setInput('taskfail', 'true');
+
 const executable = 'gitleaks-darwin-amd64';
 
 helpers.BuildWithDefaultValues();

--- a/task/tests/UploadResults_ShouldUploadFileResults.ts
+++ b/task/tests/UploadResults_ShouldUploadFileResults.ts
@@ -2,7 +2,6 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -17,7 +16,6 @@ tmr.setInput('scanfolder', __dirname);
 tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
-
 const executable = 'gitleaks-darwin-amd64';
 
 helpers.BuildWithDefaultValues();

--- a/task/tests/UploadResults_ShouldUploadFileResultsSarif.ts
+++ b/task/tests/UploadResults_ShouldUploadFileResultsSarif.ts
@@ -17,6 +17,8 @@ tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
 tmr.setInput('reportformat', 'sarif');
+tmr.setInput('taskfail', 'true');
+
 const executable = 'gitleaks-darwin-amd64';
 
 helpers.BuildWithDefaultValues();

--- a/task/tests/UploadResults_ShouldUploadFileResultsSarif.ts
+++ b/task/tests/UploadResults_ShouldUploadFileResultsSarif.ts
@@ -2,7 +2,6 @@ import * as mr from 'azure-pipelines-task-lib/mock-run';
 import * as mtr from 'azure-pipelines-task-lib/mock-toolrunner';
 
 import path = require('path');
-import os = require('os');
 import * as helpers from './MockHelper';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
@@ -18,7 +17,6 @@ tmr.setInput('nogit', 'false');
 tmr.setInput('verbose', 'false');
 tmr.setInput('uploadresults', 'true');
 tmr.setInput('reportformat', 'sarif');
-
 const executable = 'gitleaks-darwin-amd64';
 
 helpers.BuildWithDefaultValues();

--- a/task/tests/_suite.ts
+++ b/task/tests/_suite.ts
@@ -233,6 +233,26 @@ describe('Gitleaks versions', function () {
     });
 });
 
+describe('Gitleaks custom location', function () {
+    it('Should fail when custom tool cannot be found', function(done: Mocha.Done) {    
+        const tp = path.join(__dirname, 'GitleaksVersion_ShouldFailWhenCustomToolLocationCanNotBeFound.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+        assert.strictEqual(tr.succeeded, false, 'should have failed');
+        assert.strictEqual(tr.invokedToolCount, 0, 'Gitleaks tool should be invoked 0 times');
+        assert.strictEqual(tr.stdout.indexOf('loc_mock_GitLeaksNotFound') >= 0, true, "customLocation/gitleaks-darwin-amd64'");
+        done();
+    });
+    it('Should succeed with custom tool', function(done: Mocha.Done) {    
+        const tp = path.join(__dirname, 'GitleaksVersion_ShouldSucceedWithCustomLocation.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+        assert.strictEqual(tr.succeeded, true, 'should have succeeded');
+        assert.strictEqual(tr.invokedToolCount, 1, 'Gitleaks tool should be invoked 1 time');
+        done();
+    });
+});
+
 describe('Gitleaks toolcache', function () {
     it('Should download when gitleaks version is not in toolcache', function(done: Mocha.Done) {    
         const tp = path.join(__dirname, 'GitleaksRelease_ShouldDownloadWhenNotInToolCache');


### PR DESCRIPTION
- Add option for a custom tool location (so no download)
- Task input parameters are grouped
- Updated UDMSecretChecks.toml and GitleaksUdmCombo.toml to latest v7 structure (thanks to Dariusz Porowski)
- Deprecation warning of 'configtype' value custom. Use customfullpath instead. This is due to upcomming gitleaks 8
- Fixed bug that scanonlychanges (--commit-file) and depth cannot work together
- Fixed bug that reportype was a mandatory parameter, will default in code to json