### PR TITLE
Start git log at parent of first commit

### DIFF
--- a/task/v2/index.ts
+++ b/task/v2/index.ts
@@ -93,7 +93,7 @@ async function getLogOptionsForPreValidationBuild(): Promise<string | undefined>
   console.log(taskLib.loc('PreValidationScan'))
   const commitDiff = await azureDevOpsAPI.getPullRequestCommits()
   if (commitDiff === undefined || commitDiff.firstCommit === undefined || commitDiff.lastCommit === undefined) return undefined
-  return `${commitDiff.firstCommit}..${commitDiff.lastCommit}`
+  return `${commitDiff.firstCommit}~1..${commitDiff.lastCommit}`
 }
 
 async function getLogOptionsForBuildDelta(limit: number): Promise<string | undefined> {
@@ -101,7 +101,7 @@ async function getLogOptionsForBuildDelta(limit: number): Promise<string | undef
   console.log(taskLib.loc('ChangeScan', limit))
   const commitDiff = await azureDevOpsAPI.getBuildChangesCommits(limit)
   if (commitDiff === undefined || commitDiff.firstCommit === undefined || commitDiff.lastCommit === undefined) return undefined
-  return `${commitDiff.firstCommit}..${commitDiff.lastCommit}`
+  return `${commitDiff.firstCommit}~1..${commitDiff.lastCommit}`
 }
 
 async function setTaskOutcomeBasedOnGitLeaksResult(exitCode: number, reportPath: string): Promise<void> {


### PR DESCRIPTION
# Problem
The current implementation uses the first and last commit from `getPullRequestCommits()` and `getBuildChangesCommits(...)` as arguments for `git log` directly. However,  this results in the first commit to be skipped in the analysis, since `git log` only returns commits _after_ that first commit. This can be most clearly seen when using scan mode `changes`:
1. Run a build that includes this extension in scan mode `changes`
2. Create a single commit with a secret in it
3. Run the build again. Secret is not detected.

# Solution
The log options should actually start at the parent of the first commit that is returned from `getPullRequestCommits()` and `getBuildChangesCommits(...)`. This can be done by appending `~1` to the hash of the first commit in the range.

# Details
To further illustrate, consider a repo with the following history of a repo with two branches (`master` and `branch`):
```
* bded5c7 (branch) Third branch commit
* 0b55e94 Second branch commit
* 9ab1055 First branch commit
| * cac7edd (HEAD -> master) Fifth commit
| * c11297e Fourth commit
| * 8081586 Third commit
|/
* d3cec47 Second commit
* ee3384b First commit
```

Now, try:
`git log --oneline 8081586..cac7edd`
This returns:
```
cac7edd (HEAD -> master) Fifth commit
c11297e Fourth commit
```
So, it is _not_ including commit 8081586, which causes that commit to not be analyzed.

To solve, add `~1` to the first commit in the range:
`git log --oneline 8081586~1..cac7edd`
This now returns:
```
cac7edd (HEAD -> master) Fifth commit
c11297e Fourth commit
8081586 Third commit
```

And for a branch:
`git log --oneline 9ab1055..bded5c7`
This returns:
```
bded5c7 (branch) Third branch commit
0b55e94 Second branch commit
```
So, it is _not_ including the first commit in the branch (again causing that commit to not be analyzed).

Again, to solve add `~1`:
`git log --oneline 9ab1055~1..bded5c7`
Now the first commit on the branch is also returned:
```
bded5c7 (branch) Third branch commit
0b55e94 Second branch commit
9ab1055 First branch commit
```

In this same way, the initial problem can be explained. If there is only a single commit since the last build, or in a PR, the first and last commit returned from  `getPullRequestCommits()` and `getBuildChangesCommits(...)` will be the same. In that case, `git log` returns no commits (so nothing is analyzed):
`git log --oneline cac7edd..cac7edd`
Returns an empty result.

To solve, add `~1`:
`git log --oneline cac7edd~1..cac7edd`
Now the single commit is returned:
```
cac7edd (HEAD -> master) Fifth commit
```