### PR TITLE
Include first commit in range of commits to scan

### DIFF
--- a/task/v2/index.ts
+++ b/task/v2/index.ts
@@ -93,7 +93,7 @@ async function getLogOptionsForPreValidationBuild(): Promise<string | undefined>
   console.log(taskLib.loc('PreValidationScan'))
   const commitDiff = await azureDevOpsAPI.getPullRequestCommits()
   if (commitDiff === undefined || commitDiff.firstCommit === undefined || commitDiff.lastCommit === undefined) return undefined
-  return `${commitDiff.firstCommit}..${commitDiff.lastCommit}`
+  return `${commitDiff.firstCommit}^! ${commitDiff.lastCommit}`
 }
 
 async function getLogOptionsForBuildDelta(limit: number): Promise<string | undefined> {
@@ -101,7 +101,7 @@ async function getLogOptionsForBuildDelta(limit: number): Promise<string | undef
   console.log(taskLib.loc('ChangeScan', limit))
   const commitDiff = await azureDevOpsAPI.getBuildChangesCommits(limit)
   if (commitDiff === undefined || commitDiff.firstCommit === undefined || commitDiff.lastCommit === undefined) return undefined
-  return `${commitDiff.firstCommit}..${commitDiff.lastCommit}`
+  return `${commitDiff.firstCommit}^! ${commitDiff.lastCommit}`
 }
 
 async function setTaskOutcomeBasedOnGitLeaksResult(exitCode: number, reportPath: string): Promise<void> {

--- a/task/v2/test/Gitleaks_ScanModeChanges.ts
+++ b/task/v2/test/Gitleaks_ScanModeChanges.ts
@@ -24,7 +24,7 @@ tmr = new AzureDevOpsAPIMock(tmr)
   .build()
 
 const toolCall = new ToolCallBuilder()
-  .withLogOptions('lastCommitChange..firstCommitChange')
+  .withLogOptions('lastCommitChange^! firstCommitChange')
   .build()
 
 const reportCall = new ReportBuilder()

--- a/task/v2/test/Gitleaks_ScanModePrevalidation.ts
+++ b/task/v2/test/Gitleaks_ScanModePrevalidation.ts
@@ -26,7 +26,7 @@ tmr = new AzureDevOpsAPIMock(tmr)
   .build()
 
 const toolCall = new ToolCallBuilder()
-  .withLogOptions('lastCommitPr..firstCommitPr')
+  .withLogOptions('lastCommitPr^! firstCommitPr')
   .build()
 
 const reportCall = new ReportBuilder()

--- a/task/v2/test/Gitleaks_ScanModeSmartManual.ts
+++ b/task/v2/test/Gitleaks_ScanModeSmartManual.ts
@@ -23,7 +23,7 @@ tmr = new AzureDevOpsAPIMock(tmr)
   .build()
 
 const toolCall = new ToolCallBuilder()
-  .withLogOptions('lastCommitChange..firstCommitChange')
+  .withLogOptions('lastCommitChange^! firstCommitChange')
   .build()
 
 const reportCall = new ReportBuilder()

--- a/task/v2/test/Gitleaks_ScanModeSmartPullRequest.ts
+++ b/task/v2/test/Gitleaks_ScanModeSmartPullRequest.ts
@@ -25,7 +25,7 @@ tmr = new AzureDevOpsAPIMock(tmr)
   .build()
 
 const toolCall = new ToolCallBuilder()
-  .withLogOptions('lastCommitPr..firstCommitPr')
+  .withLogOptions('lastCommitPr^! firstCommitPr')
   .build()
 
 const reportCall = new ReportBuilder()


### PR DESCRIPTION
New and improved version of #44 ...

Got the solution from here: https://stackoverflow.com/questions/42937533/git-log-range-revision-including-the-range-edges
This seems to work OK, even if we include the repo's initial commit in the range.