### PR TITLE
Fix typo in rule 'id' field

### DIFF
--- a/task/v2/configs/GitleaksUdmCombo.toml
+++ b/task/v2/configs/GitleaksUdmCombo.toml
@@ -3113,7 +3113,7 @@ path = '''\.(?:cs|ps1|bat|config|xml|json|md|yml)$'''
 regex = '''(?i)(?:AccessToken|pat|token).*?[':="][a-z0-9]{52}(?:'|"|\s|[\r?\n]+)'''
 
 [[rules]]
-d = "CSCAN0240 2" 
+id = "CSCAN0240 2"
 description = "VstsPersonalAccessToken 2" 
 path = '''\.(?:cs|ps1|bat|config|xml|json|md|yml)$'''
 regex = '''(?i)(?:AccessToken|pat|token).*?[':="][a-z0-9/+]{70}==(?:'|"|\s|[\r?\n]+)'''

--- a/task/v2/configs/UDMSecretChecksv8.toml
+++ b/task/v2/configs/UDMSecretChecksv8.toml
@@ -259,7 +259,7 @@ path = '''\.(?:cs|ps1|bat|config|xml|json|md|yml)$'''
 regex = '''(?i)(?:AccessToken|pat|token).*?[':="][a-z0-9]{52}(?:'|"|\s|[\r?\n]+)'''
 
 [[rules]]
-d = "CSCAN0240 2" 
+id = "CSCAN0240 2"
 description = "VstsPersonalAccessToken 2" 
 path = '''\.(?:cs|ps1|bat|config|xml|json|md|yml)$'''
 regex = '''(?i)(?:AccessToken|pat|token).*?[':="][a-z0-9/+]{70}==(?:'|"|\s|[\r?\n]+)'''


### PR DESCRIPTION
[GitLeaks v8.19.x validates that rule IDs are not blank or null](https://github.com/gitleaks/gitleaks/pull/1463). (IDs are necessary for certain logic.)

Per https://github.com/gitleaks/gitleaks/issues/1507, this change has unintentionally caused some failures for people using your Azure DevOps extension due to a typo in the config.