### PR TITLE
Set default config as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Task version 3.1
+
+- Default config is now default task setting
+
 ## Task version 3
 
 - Only compatible with GitLeaks 8.19.0 and higher. Uses the new command structure

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Any feedback on the Azure configuration file ('UDMSecretChecks.toml') is welcome
 
 Thanks to [Dariusz Porowski](https://github.com/DariuszPorowski) for contributing and making awesome adjustments!
 
-Thanks to [Dariusz Porowski](https://github.com/DariuszPorowski) for contributing and making awesome adjustments!
-
 Thanks to [Richard Gomez](https://github.com/rgmz) for keeping track of possible issues with the extension and config file updates.
 
 ## FetchDepth

--- a/task/v3/task.json
+++ b/task/v3/task.json
@@ -11,8 +11,8 @@
   "minumumAgentVersion": "2.206.1",
   "version": {
     "Major": 3,
-    "Minor": 0,
-    "Patch": 3
+    "Minor": 1,
+    "Patch": 0
   },
   "groups": [
     {

--- a/task/v3/task.json
+++ b/task/v3/task.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 3,
     "Minor": 0,
-    "Patch": 2
+    "Patch": 3
   },
   "groups": [
     {
@@ -49,7 +49,7 @@
       "name": "configtype",
       "type": "pickList",
       "label": "Configuration Type",
-      "defaultValue": "predefined",
+      "defaultValue": "default",
       "required": true,
       "options": {
         "default": "Default",


### PR DESCRIPTION
This pull request includes updates to the `task` configuration and documentation for version 3.1. The most important changes include updating the version number, modifying the default configuration type, and adding a new entry to the changelog.

Version updates:

* [`task/v3/task.json`](diffhunk://#diff-e2a5018fed8d9b0c2d0507bf81258d2cd5b6dd424dd5da2e9ef955072ad077d4L14-R15): Updated the version number to 3.1.0.

Configuration changes:

* [`task/v3/task.json`](diffhunk://#diff-e2a5018fed8d9b0c2d0507bf81258d2cd5b6dd424dd5da2e9ef955072ad077d4L52-R52): Changed the `defaultValue` for `configtype` from "predefined" to "default".

Documentation updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Added a new entry for Task version 3.1, noting that the default config is now the default task setting.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-L39): Removed a duplicate acknowledgment for contributor Dariusz Porowski.