### PR TITLE
Reflect changes in scanmode options in nogit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This means that commits are not scanned but flat files. In this case you scan th
     scanlocation: '$(Build.SourcesDirectory)'
     configtype: 'predefined'
     predefinedconfigfile: 'GitleaksUdmCombo.toml'
-    scanmode: 'nogit'
+    scanmode: 'directory'
     reportformat: 'sarif'
 ```
 


### PR DESCRIPTION
The options for scanmode have changed and the example provided uses an unsupported option.