### PR TITLE
Clarify `scanmode` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,25 +76,25 @@ This means that commits are not scanned but flat files. In this case you scan th
 
 | Name | Description |
 | :-----|:------------ |
-| scanlocation | The location to be scanned.<br/>Defaults to $(Build.SourcesDirectory). |
-| configtype | Can be 'default', 'predefined', 'custom'.<br/>'default' for GitLeaks default configuration.<br/>'predefined' allows you to select a predefined configurations.<br/>'custom' allows you to set a custom configuration file. |
-| predefinedconfigfile | Can be 'UDMSecretChecksv8.toml' or 'GitleaksUdmCombo.toml'.<br/>'UDMSecretChecksv8.toml' uses the Credscan config file provided by Jesse Houwing.<br/>'GitleaksUdmCombo.toml' uses the default GitLeaks configuration icm the CredScan configuration.|
-| configfile | Sets the custom configfile in your repo. |
-| scanmode | 'all' will scan all commits.<br/>'prevalidation' will scan only the commits that are part of a Pull Request.<br/>'changes' will scan only the changes between this build and the previous build.<br/>'smart' will detect the best scanmode.<br/>'directory' will run GitLeaks in no-git mode (flat file scan).<br/>'custom' will allow you to provide custom -log-opts.|
-| logoptions | When scanmode is set to 'custom', this allows you to fill in custom log-options that are passed to GitLeaks |
-| redact | Redact secrets from log messages and leaks. Default is `true`. |
-| baselinePath | Specify a baseline file (old report) so that only new findings are reported. The baseline file/report should be in json format. |
-| gitLeaksIgnoreFilePath | Specify a .gitleaksignore or folder that contains one. |
-| taskfail | Sets the behavior of the task when secrets are detected.<br/>When set to `true`, fail the task. When set to `false` and secrets present end with warning. Default is `true` |
-| uploadresults | When set to `true`, the results of gitleaks will be uploaded as an artifact to Azure DevOps. Default is `true`.|
-| reportartifactname | When uploadresults is set to `true`, you can specify the artifact name in Azure DevOps. For the SARIF SAST extension to work, this should be `CodeAnalysisLogs`.|
-| reportformat | Sets gitleaks report format. Default is 'sarif'). |
-| reportfolder | Specify the report folder. Default is the agent tempdirectory. |
-| reportname | Sets the report file name. Default this will be 'gitleaks-<newguid>.<reportextension> |
-| verbose | When set to `true`, gitleaks prints verbose output. Default is `false`. |
-| version | Version of Gitleaks to be used. See the GitLeaks GitHub page.<br/>Set to 'latest' to download the latest version of GitLeaks. |
-| customtoollocation | You can set the custom location of GitLeaks. When set, GitLeaks will not be downloaded but fetched from this location. An alternative is setting a system variable named 'AGENT_TOOLSGITLEAKSDIRECTORY' to the Gitleaks tool location. This is specially for agents that do not have an internet connection. You can only set file paths. |
-| taskfailonexecutionerror | Sets the behavior of the task when execution errors occurs.<br/>When set to `true`, fail the task. When set to `false` and the tasks fails to execute the task is SuccededWithWarnings. Default is `true` |
+| `scanlocation` | The location to be scanned.<br/>Defaults to `$(Build.SourcesDirectory)`. |
+| `configtype` | Can be `'default'`, `'predefined'`, `'custom'`.<br/>`'default'` for GitLeaks default configuration.<br/>`'predefined'` allows you to select a predefined configurations.<br/>`'custom'` allows you to set a custom configuration file. |
+| `predefinedconfigfile` | Can be `'UDMSecretChecksv8.toml'` or `'GitleaksUdmCombo.toml'`.<br/>`'UDMSecretChecksv8.toml'` uses the Credscan config file provided by Jesse Houwing.<br/>`'GitleaksUdmCombo.toml'` uses the default GitLeaks configuration icm th`e CredScan configuration.|
+| `configfile` | Sets the custom configfile in your repo. |
+| `scanmode` | `'all'` will scan all commits.<br/>`'prevalidation'` will scan only the commits that are part of a Pull Request.<br/>`'changes'` will scan only the changes between this build and the previous build.<br/>`'smart'` will detect the best scanmode.<br/>`'directory'` will run GitLeaks in no-git mode (flat file scan).<br/>`'custom'` will allow you to provide custom -log-opts.|
+| `logoptions` | When scanmode is set to `'custom'`, this allows you to fill in custom log-options that are passed to GitLeaks |
+| `redact` | Redact secrets from log messages and leaks. Default is `true`. |
+| `baselinePath` | Specify a baseline file (old report) so that only new findings are reported. The baseline file/report should be in json format. |
+| `gitLeaksIgnoreFilePath` | Specify a `.gitleaksignore` or folder that contains one. |
+| `taskfail` | Sets the behavior of the task when secrets are detected.<br/>When set to `true`, fail the task. When set to `false` and secrets present end with warning. Default is `true` |
+| `uploadresults` | When set to `true`, the results of gitleaks will be uploaded as an artifact to Azure DevOps. Default is `true`.|
+| `reportartifactname` | When uploadresults is set to `true`, you can specify the artifact name in Azure DevOps. For the SARIF SAST extension to work, this should be `CodeAnalysisLogs`.|
+| `reportformat` | Sets gitleaks report format. Default is `'sarif'`. |
+| `reportfolder` | Specify the report folder. Default is the agent tempdirectory. |
+| `reportname` | Sets the report file name. Default this will be `'gitleaks-<newguid>.<reportextension>'` |
+| `verbose` | When set to `true`, gitleaks prints verbose output. Default is `false`. |
+| `version` | Version of Gitleaks to be used. See the GitLeaks GitHub page.<br/>Set to `'latest'` to download the latest version of GitLeaks. |
+| `customtoollocation` | You can set the custom location of GitLeaks. When set, GitLeaks will not be downloaded but fetched from this location. An alternative is setting a system variable named 'AGENT_TOOLSGITLEAKSDIRECTORY' to the Gitleaks tool lo`cation. This is specially for agents that do not have an internet connection. You can only set file paths. |
+| `taskfailonexecutionerror` | Sets the behavior of the task when execution errors occurs.<br/>When set to `true`, fail the task. When set to `false` and the tasks fails to execute the task is SuccededWithWarnings. Default is `true` |
 
 
 ### Notes for GitHub repositories:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See also the [Microsoft Documentation on this](https://learn.microsoft.com/en-us
 
 For coorporate environments setting variable `Agent.Source.Git.ShallowFetchDepth` to `0` can set this for every pipeline.
 
-### Set the scan mode to nogit
+### Set the scan mode to `directory`
 
 This means that commits are not scanned but flat files. In this case you scan the as-if situation. Secrets  commited but that are not in the HEAD will not be found. 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For coorporate environments setting variable `Agent.Source.Git.ShallowFetchDepth
 
 ### Set the scan mode to `directory`
 
-This means that commits are not scanned but flat files. In this case you scan the as-if situation. Secrets  commited but that are not in the HEAD will not be found. 
+This means that commits are not scanned but flat files. In this case you scan the as-if situation. Secrets commited but that are not in the HEAD will not be found.
 
 ```yaml
 # Run Gitleaks on Source Repository


### PR DESCRIPTION
(Edit to add a description)

This fixes #108 

It mainly updates the heading in the README that currently reads `### Set the scan mode to nogit` to be `` ### Set the scan mode to `directory` ``

It also adds inline-code formatting throughout the README for task argument names and their values, and removes some extra whitespace.  