### PR TITLE
fix: remove extra quote in author field of task metadata

### DIFF
--- a/task/v3/task.json
+++ b/task/v3/task.json
@@ -8,7 +8,7 @@
   "category": "Utility",
   "visibility": ["Build"],
   "runsOn": ["Agent"],
-  "author": "Joost Voskuil / Sebastian Goscinski'",
+  "author": "Joost Voskuil / Sebastian Goscinski",
   "minumumAgentVersion": "2.206.1",
   "version": {
     "Major": 3,


### PR DESCRIPTION
my ocd couldn’t unsee it
<img width="1155" height="271" alt="image" src="https://github.com/user-attachments/assets/4980f30b-1cc3-4e6c-9cbc-18c8d1b68ff8" />
